### PR TITLE
ClassPathUtil optimization, closes #4

### DIFF
--- a/Plugins-API/src/test/java/com/github/unafraid/plugins/ClassPathTest.java
+++ b/Plugins-API/src/test/java/com/github/unafraid/plugins/ClassPathTest.java
@@ -21,6 +21,7 @@
  */
 package com.github.unafraid.plugins;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.junit.Assert;
@@ -37,7 +38,21 @@ public class ClassPathTest
 	@Test
 	public void pluginInstallerClassPath() throws Exception
 	{
-		final List<Class<IPluginInstaller>> classes = ClassPathUtil.getAllClassesExtending(IPluginInstaller.class);
+		final List<Class<? extends IPluginInstaller>> classes = 
+				ClassPathUtil.getAllClassesExtending("com.github.unafraid.plugins", IPluginInstaller.class).toList();
 		Assert.assertNotEquals(classes.size(), 0);
 	}
+	
+	@Test
+	public void testDiscovery() throws IOException
+	{
+		final List<Class<?>> classes1 = ClassPathUtil.getAllClasses("com").toList();
+		final List<Class<?>> classes2 = ClassPathUtil.getAllClasses("com.github.unafraid").toList();
+		final List<Class<?>> classes3 = ClassPathUtil.getAllClasses("com.github.unafraid.plugins.util").toList();
+		
+		Assert.assertTrue(classes1.size() > classes2.size());
+		Assert.assertTrue(classes2.size() > classes3.size());
+		Assert.assertTrue(classes3.size() > 0);
+	}
+	
 }

--- a/Plugins-DB/build.gradle
+++ b/Plugins-DB/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
 	compile project(":Plugins-API")
 	compile(group: "org.jdbi", name: "jdbi", version: "2.78")
+	
+	testCompile (group: 'junit', name: 'junit', version: '4.12')
 }

--- a/Plugins-DB/src/main/java/com/github/unafraid/plugins/db/IDatabaseFactory.java
+++ b/Plugins-DB/src/main/java/com/github/unafraid/plugins/db/IDatabaseFactory.java
@@ -43,8 +43,4 @@ public interface IDatabaseFactory
 	 */
 	DataSource getDataSource();
 	
-	/**
-	 * Shutdowns your database factory.
-	 */
-	void shutdown();
 }

--- a/Plugins-DB/src/test/java/com/github/unafraid/plugins/db/TestDatabaseProvider.java
+++ b/Plugins-DB/src/test/java/com/github/unafraid/plugins/db/TestDatabaseProvider.java
@@ -21,51 +21,24 @@
  */
 package com.github.unafraid.plugins.db;
 
-import java.util.ArrayList;
-import java.util.ServiceLoader;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
-import org.skife.jdbi.v2.DBI;
+import org.junit.Assert;
+import org.junit.Test;
 
-import com.google.common.collect.Lists;
+import com.github.unafraid.plugins.util.ClassPathUtil;
 
-/**
- * A class used to let the plugin API know what kind of Database Factory you use.
- * @author UnAfraid
- */
-public class DatabaseProvider
+public class TestDatabaseProvider
 {
-	public static final IDatabaseFactory DATABASE_FACTORY;
-	public static final DBI DBI;
-	
-	static
+	@Test
+	public void testIDatabaseFactoryExistenceOnClassPath() throws IOException
 	{
-		try
-		{
-			final ArrayList<IDatabaseFactory> availableDatabaseFactories = Lists.newArrayList(ServiceLoader.load(IDatabaseFactory.class));
-			
-			if (availableDatabaseFactories.size() != 1) {
-				throw new IllegalStateException("Invalid amount of provided database factories found: " + availableDatabaseFactories);
-			}
-			
-			DATABASE_FACTORY = availableDatabaseFactories.get(0);
-		}
-		catch (Exception e)
-		{
-			throw new RuntimeException(e);
-		}
+		final Set<Class<? extends IDatabaseFactory>> classes = 
+				ClassPathUtil.getAllClassesExtending("com.github.unafraid", IDatabaseFactory.class).toSet();
 		
-		try
-		{
-			DBI = new DBI(DATABASE_FACTORY.getDataSource());
-		}
-		catch (Exception e)
-		{
-			throw new RuntimeException(e);
-		}
+		Assert.assertEquals(Collections.singleton(IDatabaseFactory.class), classes);
 	}
 	
-	private DatabaseProvider()
-	{
-		// Hide constructor.
-	}
 }


### PR DESCRIPTION
- caching ClassPath objects for performance benefits
- dropped complete classpath scanning methods due to performance considerations
- replaced classpath scanning for DatabaseProvider with service providers
- added support for providing the ClassLoader externally