### PR TITLE
ClassLoader unload support

### DIFF
--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
@@ -55,6 +55,7 @@ public abstract class AbstractPlugin {
 	private final List<IPluginInstaller> installers = new ArrayList<>(Collections.singleton(fileInstaller));
 	private final AtomicReference<PluginState> state = new AtomicReference<>(PluginState.AVAILABLE);
 	private final Set<IPluginFunction<? extends AbstractPlugin>> functions = new LinkedHashSet<>();
+	private Path pluginsPath;
 	private Path jarPath;
 	private String jarHash;
 	
@@ -319,6 +320,14 @@ public abstract class AbstractPlugin {
 		return migrations;
 	}
 	
+	final void setPluginsPath(Path pluginsPath) {
+		this.pluginsPath = pluginsPath;
+	}
+	
+	public final Path getPluginsPath() {
+		return pluginsPath;
+	}
+	
 	final void setJarPath(Path jarPath) {
 		this.jarPath = jarPath;
 	}
@@ -344,7 +353,7 @@ public abstract class AbstractPlugin {
 		final String[] totalPaths = new String[paths.length + 1];
 		totalPaths[0] = getName();
 		System.arraycopy(paths, 0, totalPaths, 1, paths.length);
-		return Paths.get("plugins", totalPaths).normalize();
+		return getPluginsPath().resolve(Paths.get("", totalPaths)).normalize();
 	}
 	
 	/**
@@ -358,7 +367,7 @@ public abstract class AbstractPlugin {
 	
 	/**
 	 * Gets the string version of {@link #getAbsolutePath(String...)}, uses {@link Path#toString()}.
-	 * @param paths
+	 * @param paths path parameters given by the user
 	 * @return absolute path
 	 */
 	public final String getAbsolutePathString(String... paths) {

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
@@ -320,26 +320,50 @@ public abstract class AbstractPlugin {
 		return migrations;
 	}
 	
+	/**
+	 * Sets the plugin root that is being used by plugin file installers.
+	 * @param pluginsPath the plugin root chosen by the user
+	 */
 	final void setPluginsPath(Path pluginsPath) {
 		this.pluginsPath = pluginsPath;
 	}
 	
+	/**
+	 * Gets the plugin root path that is being used by plugin file installers.
+	 * @return plugins path
+	 */
 	public final Path getPluginsPath() {
 		return pluginsPath;
 	}
 	
+	/**
+	 * Sets the JAR file's path. (internal usage only)
+	 * @param jarPath path of the JAR that contains the plugin
+	 */
 	final void setJarPath(Path jarPath) {
 		this.jarPath = jarPath;
 	}
 	
+	/**
+	 * Gets the JAR file's path that contains the plugin.
+	 * @return JAR file's path
+	 */
 	public final Path getJarPath() {
 		return jarPath;
 	}
 	
+	/**
+	 * Sets the JAR's hash. (internal usage only)
+	 * @param jarHash the hash of the JAR file that contains the plugin
+	 */
 	final void setJarHash(String jarHash) {
 		this.jarHash = jarHash;
 	}
 	
+	/**
+	 * Gets the JAR file's hash that contains the plugin.
+	 * @return JAR hash
+	 */
 	public final String getJarHash() {
 		return jarHash;
 	}

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
@@ -54,6 +54,8 @@ public abstract class AbstractPlugin {
 	private final List<IPluginInstaller> installers = new ArrayList<>(Collections.singleton(fileInstaller));
 	private final AtomicReference<PluginState> state = new AtomicReference<>(PluginState.AVAILABLE);
 	private final Set<IPluginFunction<? extends AbstractPlugin>> functions = new LinkedHashSet<>();
+	private Path jarPath;
+	private String jarHash;
 	
 	/**
 	 * Gets the name of the plugin.<br>
@@ -316,6 +318,22 @@ public abstract class AbstractPlugin {
 		return migrations;
 	}
 	
+	final void setJarPath(Path jarPath) {
+		this.jarPath = jarPath;
+	}
+	
+	public final Path getJarPath() {
+		return jarPath;
+	}
+	
+	final void setJarHash(String jarHash) {
+		this.jarHash = jarHash;
+	}
+	
+	public final String getJarHash() {
+		return jarHash;
+	}
+	
 	/**
 	 * Normalises the path of the plugin.
 	 * @param paths path parameters given by the user
@@ -380,6 +398,7 @@ public abstract class AbstractPlugin {
 		result = (prime * result) + ((getAuthor() == null) ? 0 : getAuthor().hashCode());
 		result = (prime * result) + ((getCreatedAt() == null) ? 0 : getCreatedAt().hashCode());
 		result = (prime * result) + ((getDescription() == null) ? 0 : getDescription().hashCode());
+		result = (prime * result) + ((getJarHash() == null) ? 0 : getJarHash().hashCode());
 		result = (prime * result) + getVersion();
 		return result;
 	}
@@ -407,6 +426,9 @@ public abstract class AbstractPlugin {
 			return false;
 		}
 		if (!Objects.equals(getDescription(), other.getDescription())) {
+			return false;
+		}
+		if (!Objects.equals(getJarHash(), other.getJarHash())) {
 			return false;
 		}
 		if (getVersion() != other.getVersion()) {

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/AbstractPlugin.java
@@ -39,6 +39,7 @@ import com.github.unafraid.plugins.installers.IPluginInstaller;
 import com.github.unafraid.plugins.installers.file.FileInstaller;
 import com.github.unafraid.plugins.migrations.PluginMigrations;
 import com.github.unafraid.plugins.util.ThrowableRunnable;
+import com.google.common.base.MoreObjects;
 
 /**
  * This class is the parent class of all plugins.<br>
@@ -436,5 +437,17 @@ public abstract class AbstractPlugin {
 		}
 		
 		return true;
+	}
+	
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+			.add("name", getName())
+			.add("author", getAuthor())
+			.add("createdAt", getCreatedAt())
+			.add("description", getDescription())
+			.add("jarHash", getJarHash())
+			.add("version", getVersion())
+			.toString();
 	}
 }

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/PluginRepository.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/PluginRepository.java
@@ -145,29 +145,7 @@ public class PluginRepository<T extends AbstractPlugin> {
 		Objects.requireNonNull(plugin.getJarHash());
 		
 		final Map<String, T> plugins = this.plugins.computeIfAbsent(plugin.getName(), k -> new HashMap<>());
-		if (plugins.containsKey(plugin.getJarHash())) {
-			// Don't do anything if the JAR hash is the same.
-			return;
-		}
-		
-		final T oldPlugin = plugins.put(plugin.getJarHash(), plugin);
-		if (oldPlugin != null) {
-			final boolean wasStarted = oldPlugin.getState() == PluginState.STARTED;
-			
-			// After re-scan plugin might be changed, so stop first.
-			if (wasStarted) {
-				oldPlugin.stop();
-			}
-			
-			// ClassLoader cleanup.
-			cleanupClassLoader(oldPlugin);
-			
-			// Start again.
-			if (wasStarted) {
-				plugin.start();
-			}
-		}
-		
+		plugins.put(plugin.getJarHash(), plugin);
 		classLoaders.put(plugin, classLoader);
 	}
 	
@@ -254,7 +232,7 @@ public class PluginRepository<T extends AbstractPlugin> {
 		return plugins.values()
 			.stream()
 			.flatMap(map -> map.values().stream())
-			.sorted(Comparator.comparingInt(T::getVersion).reversed());
+			.sorted(Comparator.comparing(T::getJarHash).reversed());
 	}
 	
 	/**

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/PluginRepository.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/PluginRepository.java
@@ -87,6 +87,7 @@ public class PluginRepository<T extends AbstractPlugin> {
 								final URL url = path.toUri().toURL();
 								final URLClassLoader classLoader = parentClassLoader != null ? new URLClassLoader(new URL[] { url }, parentClassLoader) : new URLClassLoader(new URL[] { url });
 								for (T plugin : ServiceLoader.load(pluginClass, classLoader)) {
+									plugin.setPluginsPath(pluginsPath);
 									plugin.setJarPath(path);
 									plugin.setJarHash(FileHashUtil.getFileHash(path).toString());
 									
@@ -111,6 +112,7 @@ public class PluginRepository<T extends AbstractPlugin> {
 		
 		// Scan general class loader for plug-ins (Debug project include)
 		for (T plugin : ServiceLoader.load(pluginClass)) {
+			plugin.setPluginsPath(pluginsPath);
 			plugin.setJarPath(PathUtil.getClassLocation(pluginClass));
 			plugin.setJarHash(IDE_MODE);
 			

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/PluginRepository.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/PluginRepository.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import com.github.unafraid.plugins.exceptions.PluginException;
 import com.github.unafraid.plugins.util.FileHashUtil;
+import com.github.unafraid.plugins.util.JarClassLoader;
 import com.github.unafraid.plugins.util.PathUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +86,7 @@ public class PluginRepository<T extends AbstractPlugin> {
 						{
 							try {
 								final URL url = path.toUri().toURL();
-								final URLClassLoader classLoader = parentClassLoader != null ? new URLClassLoader(new URL[] { url }, parentClassLoader) : new URLClassLoader(new URL[] { url });
+								final JarClassLoader classLoader = parentClassLoader != null ? new JarClassLoader(new URL[] { url }, parentClassLoader) : new JarClassLoader(new URL[] { url });
 								for (T plugin : ServiceLoader.load(pluginClass, classLoader)) {
 									plugin.setPluginsPath(pluginsPath);
 									plugin.setJarPath(path);

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/util/FileHashUtil.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/util/FileHashUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Rumen Nikiforov <unafraid89@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.unafraid.plugins.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+
+/**
+ * @author lord_rex
+ */
+public final class FileHashUtil {
+	private FileHashUtil() {
+		// utility class
+	}
+	
+	public static HashCode getFileHash(File file) throws IOException {
+		return Files.asByteSource(file).hash(Hashing.sha512());
+	}
+	
+	public static HashCode getFileHash(Path path) throws IOException {
+		return getFileHash(path.toFile());
+	}
+}

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/util/JarClassLoader.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/util/JarClassLoader.java
@@ -35,38 +35,43 @@ public class JarClassLoader extends URLClassLoader {
 	public JarClassLoader(URL[] urls, ClassLoader parent) {
 		super(urls, parent);
 	}
-
+	
 	public JarClassLoader(URL[] urls) {
 		super(urls);
 	}
-
+	
 	@Override
 	public void close() throws IOException {
 		try {
 			final Field ucpField = getClass().getDeclaredField("ucp");
 			ucpField.setAccessible(true);
-
+			
 			final Object classPath = ucpField.get(this);
 			final Field loadersField = classPath.getClass().getDeclaredField("loaders");
 			loadersField.setAccessible(true);
-
+			
 			final Object loadersCollection = loadersField.get(classPath);
 			if (loadersCollection instanceof Collection) {
 				for (Object jarClassLoader : ((Collection) loadersCollection)) {
 					try {
 						final Field jarField = jarClassLoader.getClass().getDeclaredField("jar");
 						jarField.setAccessible(true);
-
+						
 						final Object jarFile = jarField.get(jarClassLoader);
 						if (jarFile instanceof Closeable) {
 							((Closeable) jarFile).close();
 						}
-					} catch (Exception e) {
+					}
+					catch (Exception e) {
+						// ignore
 					}
 				}
 			}
-		} catch (Exception e) {
 		}
+		catch (Exception e) {
+			// ignore
+		}
+		
 		super.close();
 	}
 }

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/util/JarClassLoader.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/util/JarClassLoader.java
@@ -51,16 +51,18 @@ public class JarClassLoader extends URLClassLoader {
 			loadersField.setAccessible(true);
 
 			final Object loadersCollection = loadersField.get(classPath);
-			for (Object jarClassLoader : ((Collection) loadersCollection).toArray()) {
-				try {
-					final Field jarField = jarClassLoader.getClass().getDeclaredField("jar");
-					jarField.setAccessible(true);
+			if (loadersCollection instanceof Collection) {
+				for (Object jarClassLoader : ((Collection) loadersCollection)) {
+					try {
+						final Field jarField = jarClassLoader.getClass().getDeclaredField("jar");
+						jarField.setAccessible(true);
 
-					final Object jarFile = jarField.get(jarClassLoader);
-					if (jarFile instanceof Closeable) {
-						((Closeable) jarFile).close();
+						final Object jarFile = jarField.get(jarClassLoader);
+						if (jarFile instanceof Closeable) {
+							((Closeable) jarFile).close();
+						}
+					} catch (Exception e) {
 					}
-				} catch (Exception e) {
 				}
 			}
 		} catch (Exception e) {

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/util/JarClassLoader.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/util/JarClassLoader.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017 Rumen Nikiforov <unafraid89@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.unafraid.plugins.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collection;
+
+/**
+ * @author UnAfraid
+ */
+public class JarClassLoader extends URLClassLoader {
+	public JarClassLoader(URL[] urls, ClassLoader parent) {
+		super(urls, parent);
+	}
+
+	public JarClassLoader(URL[] urls) {
+		super(urls);
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			final Field ucpField = getClass().getDeclaredField("ucp");
+			ucpField.setAccessible(true);
+
+			final Object classPath = ucpField.get(this);
+			final Field loadersField = classPath.getClass().getDeclaredField("loaders");
+			loadersField.setAccessible(true);
+
+			final Object loadersCollection = loadersField.get(classPath);
+			for (Object jarClassLoader : ((Collection) loadersCollection).toArray()) {
+				try {
+					final Field jarField = jarClassLoader.getClass().getDeclaredField("jar");
+					jarField.setAccessible(true);
+
+					final Object jarFile = jarField.get(jarClassLoader);
+					if (jarFile instanceof Closeable) {
+						((Closeable) jarFile).close();
+					}
+				} catch (Exception e) {
+				}
+			}
+		} catch (Exception e) {
+		}
+		super.close();
+	}
+}

--- a/Plugins-API/src/main/java/com/github/unafraid/plugins/util/PathUtil.java
+++ b/Plugins-API/src/main/java/com/github/unafraid/plugins/util/PathUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Rumen Nikiforov <unafraid89@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.unafraid.plugins.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author lord_rex
+ */
+public final class PathUtil {
+	private PathUtil() {
+		// utility class
+	}
+	
+	public static Path getClassLocation(Class<?> clazz) {
+		try {
+			final URI uri = clazz.getProtectionDomain().getCodeSource().getLocation().toURI();
+			return Paths.get(uri);
+		}
+		catch (URISyntaxException e) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Usage:

```
unload(plugin); // unload old JAR from the PluginRepository
Files.deleteIfExists(plugin.getJarPath()); // to make sure nothing keeps the JAR in memory anymore
downloadNewPluginJAR(); // fetch the new JAR from a site, or whatever
scan(); // load the new JAR into the memory
```